### PR TITLE
Private property compiler error

### DIFF
--- a/src/client/core/bootstrap.client.tsx
+++ b/src/client/core/bootstrap.client.tsx
@@ -10,7 +10,6 @@ const playerGui = player.WaitForChild("PlayerGui");
 
 const fabric = new FabricLib.Fabric("Example");
 {
-	fabric.DEBUG = true;
 	FabricLib.useReplication(fabric);
 	FabricLib.useTags(fabric);
 	FabricLib.useBatching(fabric);

--- a/src/server/core/runTime.server.ts
+++ b/src/server/core/runTime.server.ts
@@ -26,7 +26,6 @@ const fabric = new FabricLib.Fabric("Example");
 	FabricLib.useTags(fabric);
 	FabricLib.useBatching(fabric);
 	fabric.registerUnitsIn(ServerScriptService.TS.units);
-	fabric.DEBUG = true;
 }
 
 function createHealthPack(character: CharacterRigR15) {


### PR DESCRIPTION
Fixes an error with private properties for fabric.
The issue appeared both on the client(bootstrap.server.ts) and server(runTime.server.ts).