### PR TITLE
Make damage indicators more visible

### DIFF
--- a/src/client/UserInterface/App/HitMark.tsx
+++ b/src/client/UserInterface/App/HitMark.tsx
@@ -1,4 +1,5 @@
 import Roact from "@rbxts/roact";
+import { Workspace } from "@rbxts/services";
 
 interface Props {
 	hit: string;
@@ -6,8 +7,10 @@ interface Props {
 
 class HitMark extends Roact.Component<Props> {
 	render() {
+		const absoluteSize = Workspace.CurrentCamera!.ViewportSize.div(15);
+
 		return (
-			<billboardgui AlwaysOnTop={true} Size={new UDim2(1, 25, 1, 25)}>
+			<billboardgui AlwaysOnTop={true} Size={UDim2.fromOffset(absoluteSize.X, absoluteSize.Y)}>
 				<textlabel
 					AnchorPoint={new Vector2(0.5, 0.5)}
 					Position={new UDim2(0.5, 0, 0.5, 0)}
@@ -15,7 +18,8 @@ class HitMark extends Roact.Component<Props> {
 					BackgroundTransparency={1}
 					Font={Enum.Font.GothamBlack}
 					Text={this.props.hit}
-					Size={new UDim2(1, 0, 1, 0)}
+					TextStrokeTransparency={0}
+					Size={UDim2.fromScale(1, 1)}
 					TextColor3={new Color3(188, 0, 0)}
 				/>
 				<uisizeconstraint MaxSize={new Vector2(75, 75)} />


### PR DESCRIPTION
Probably not the best solution, but it divides the viewport size and uses it as an offset.
The text stroke is also visible.